### PR TITLE
Add option for triplet inputs to RN

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,7 +116,7 @@ def train(epoch, ternary, rel, norel):
         acc_norels.append(accuracy_norel.item())
 
         if batch_idx % args.log_interval == 0:
-            print('Train Epoch: {} [{}/{} ({:.0f}%)] Ternary accuracy: {:.0f}% | Relations accuracy: {:.0f}% | Non-relations accuracy: {:.0f}%'.format(epoch, batch_idx * bs * 2, len(rel[0]) * 2,
+            print('Train Epoch: {} [{}/{} ({:.0f}%)] Ternary accuracy: {:.0f}% | Binary accuracy: {:.0f}% | Unary accuracy: {:.0f}%'.format(epoch, batch_idx * bs * 2, len(rel[0]) * 2,
                                                                                                                            100. * batch_idx * bs / len(rel[0]), accuracy_ternary, accuracy_rel, accuracy_norel))
 
     # return average accuracy                                                                                                                  
@@ -148,7 +148,7 @@ def test(epoch, ternary, rel, norel):
     accuracy_ternary = sum(accuracy_ternary) / len(accuracy_ternary)
     accuracy_rel = sum(accuracy_rels) / len(accuracy_rels)
     accuracy_norel = sum(accuracy_norels) / len(accuracy_norels)
-    print('\n Test set: Teneray accuracy: {:.0f}% Relation accuracy: {:.0f}% | Non-relation accuracy: {:.0f}%\n'.format(
+    print('\n Test set: Teneray accuracy: {:.0f}% Binary accuracy: {:.0f}% | Unary accuracy: {:.0f}%\n'.format(
         accuracy_ternary, accuracy_rel, accuracy_norel))
     return accuracy_ternary.item(), accuracy_rel.item(), accuracy_norel.item()
 
@@ -205,15 +205,15 @@ if args.resume:
 
 with open(f'./{args.model}_{args.seed}_log.csv', 'w') as log_file:
     writer = csv.writer(log_file, delimiter=',')
-    writer.writerow(['epoch', 'train_acc_ternary','train_acc_rel',
-                     'train_acc_norel', 'train_acc_ternary', 'test_acc_rel', 'test_acc_norel'])
+    writer.writerow(['epoch', 'train_acc_ternary','train_acc_binary',
+                     'train_acc_unary', 'train_acc_ternary', 'test_acc_binary', 'test_acc_unary'])
 
     for epoch in range(1, args.epochs + 1):
-        train_acc_ternary, train_acc_rel, train_acc_norel = train(
+        train_acc_ternary, train_acc_binary, train_acc_unary = train(
             epoch, ternary_train, rel_train, norel_train)
-        test_acc_ternary, test_acc_rel, test_acc_norel = test(
+        test_acc_ternary, test_acc_binary, test_acc_unary = test(
             epoch, ternary_test, rel_test, norel_test)
 
-        writer.writerow([epoch, train_acc_ternary, train_acc_rel,
-                         train_acc_norel, test_acc_ternary, test_acc_rel, test_acc_norel])
+        writer.writerow([epoch, train_acc_ternary, train_acc_binary, train_acc_unary,
+                         test_acc_ternary, test_acc_binary, test_acc_unary])
         model.save_model(epoch)

--- a/main.py
+++ b/main.py
@@ -35,6 +35,8 @@ parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                     help='how many batches to wait before logging training status')
 parser.add_argument('--resume', type=str,
                     help='resume from model stored')
+parser.add_argument('--relation-type', type=str, default='binary',
+                    help='what kind of relations to learn. options: binary, ternary (default: binary')
 
 args = parser.parse_args()
 args.cuda = not args.no_cuda and torch.cuda.is_available()

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ parser.add_argument('--log-interval', type=int, default=10, metavar='N',
 parser.add_argument('--resume', type=str,
                     help='resume from model stored')
 parser.add_argument('--relation-type', type=str, default='binary',
-                    help='what kind of relations to learn. options: binary, ternary (default: binary')
+                    help='what kind of relations to learn. options: binary, ternary (default: binary)')
 
 args = parser.parse_args()
 args.cuda = not args.no_cuda and torch.cuda.is_available()

--- a/model.py
+++ b/model.py
@@ -51,8 +51,6 @@ class FCOutputModel(nn.Module):
         x = self.fc3(x)
         return F.log_softmax(x)
 
-  
-
 class BasicModel(nn.Module):
     def __init__(self, args, name):
         super(BasicModel, self).__init__()
@@ -146,29 +144,28 @@ class RN(BasicModel):
             # add question everywhere
             qst = torch.unsqueeze(qst, 1) # (64x1x18)
             qst = qst.repeat(1, 25, 1) # (64x25x18)
-            qst = torch.unsqueeze(qst, 2)  # (64x25x1x18)
-            qst = torch.unsqueeze(qst, 3)  # (64x25x1x1x18)
+            qst = torch.unsqueeze(qst, 1)  # (64x1x25x18)
+            qst = torch.unsqueeze(qst, 1)  # (64x1x1x25x18)
 
-            # cast all pairs against each other
-            x_i = torch.unsqueeze(x_flat, 1)  # (64x1x25x26+18)
-            x_i = torch.unsqueeze(x_i, 3)  # (64x1x25x1x26+18)
-            x_i = x_i.repeat(1, 25, 1, 25, 1)  # (64x25x25x25x26+18)
+            # cast all triples against each other
+            x_i = torch.unsqueeze(x_flat, 1)  # (64x1x25x26)
+            x_i = torch.unsqueeze(x_i, 3)  # (64x1x25x1x26)
+            x_i = x_i.repeat(1, 25, 1, 25, 1)  # (64x25x25x25x26)
             
-            x_j = torch.unsqueeze(x_flat, 2)  # (64x25x1x26+18)
-            x_j = torch.unsqueeze(x_j, 2)  # (64x25x1x1x26+18)
-            x_j = torch.cat([x_j, qst], 4)
-            x_j = x_j.repeat(1, 1, 25, 25, 1)  # (64x25x25x25x26+18)
+            x_j = torch.unsqueeze(x_flat, 2)  # (64x25x1x26)
+            x_j = torch.unsqueeze(x_j, 2)  # (64x25x1x1x26)
+            x_j = x_j.repeat(1, 1, 25, 25, 1)  # (64x25x25x25x26)
 
-            x_k = torch.unsqueeze(x_flat, 1)  # (64x1x25x26+18)
-            x_k = torch.unsqueeze(x_k, 1)  # (64x1x1x25x26+18)
+            x_k = torch.unsqueeze(x_flat, 1)  # (64x1x25x26)
+            x_k = torch.unsqueeze(x_k, 1)  # (64x1x1x25x26)
+            x_k = torch.cat([x_k, qst], 4)  # (64x1x1x25x26+18)
             x_k = x_k.repeat(1, 25, 25, 1, 1)  # (64x25x25x25x26+18)
-
 
             # concatenate all together
             x_full = torch.cat([x_i, x_j, x_k], 4)  # (64x25x25x25x3*26+18)
 
             # reshape for passing through network
-            x_ = x_full.view(mb*(d*d)*(d*d)*(d*d), 96)  # (64*25*25*25x3*26*18) = (1.000.000, 96)
+            x_ = x_full.view(mb * (d * d) * (d * d) * (d * d), 96)  # (64*25*25*25x3*26+18) = (1.000.000, 96)
         else:
             # add question everywhere
             qst = torch.unsqueeze(qst, 1)


### PR DESCRIPTION
With the arg `--relation-type ternary` triples as input to the RN are enables.
The first layer of the `g` network is extended to fit 3 objects, the remaining module stays the same.

Bonus: Improved naming in console prints and csv logging