### PR TITLE
Update 'between' subtype question and answer generation

### DIFF
--- a/model.py
+++ b/model.py
@@ -184,7 +184,7 @@ class RN(BasicModel):
             x_full = torch.cat([x_i,x_j],3) # (64x25x25x2*26+18)
         
             # reshape for passing through network
-            x_ = x_full.view(mb * (d * d) * (d * d), 70)  # (64*25*25x2*26*18) = (40.000, 70)
+            x_ = x_full.view(mb * (d * d) * (d * d), 70)  # (64*25*25x2*26+18) = (40.000, 70)
             
         x_ = self.g_fc1(x_)
         x_ = F.relu(x_)

--- a/sort_of_clevr_generator.py
+++ b/sort_of_clevr_generator.py
@@ -200,9 +200,9 @@ def build_dataset():
 
             answer = between_count + 4
         elif subtype == 1:
-            """is-on-line->yes/no"""
+            """is-on-band->yes/no"""
             
-            grace_threshold = 2.5  # half of the size of objects
+            grace_threshold = 12  # half of the size of objects
             epsilon = 1e-10  
             m = (B[1]-A[1])/((B[0]-A[0]) + epsilon ) # add epsilon to prevent dividing by zero
             c = A[1] - (m*A[0])

--- a/sort_of_clevr_generator.py
+++ b/sort_of_clevr_generator.py
@@ -24,7 +24,7 @@ size = 5
 question_size = 18  ## 2 x (6 for one-hot vector of color), 3 for question type, 3 for question subtype
 q_type_idx = 12
 sub_q_type_idx = 15
-"""Answer : [yes, no, rectangle, circle, r, g, b, o, k, y]"""
+"""Answer : [yes, no, rectangle, circle, 1, 2, 3, 4, 5, 6]"""
 
 nb_questions = 10
 dirs = './data'
@@ -88,7 +88,7 @@ def build_dataset():
         subtype = random.randint(0,2)
         question[subtype+sub_q_type_idx] = 1
         norel_questions.append(question)
-        """Answer : [yes, no, rectangle, circle, r, g, b, o, k, y]"""
+        """Answer : [yes, no, rectangle, circle, 1, 2, 3, 4, 5, 6]"""
         if subtype == 0:
             """query shape->rectangle/circle"""
             if objects[color][2] == 'r':

--- a/sort_of_clevr_generator.py
+++ b/sort_of_clevr_generator.py
@@ -174,14 +174,15 @@ def build_dataset():
         question[subtype+sub_q_type_idx] = 1
         ternary_questions.append(question)
 
-        # get coordiantes of object from question
+        # get coordinates of object from question
         A = objects[color1][1]
         B = objects[color2][1]
 
         if subtype == 0:
-            """between->1~4"""
+            """between->yes/no"""
 
-            between_count = 0 
+            answer = 1  # default answer is 'no'
+
             # check is any objects lies inside the box
             for other_obj in objects:
                 # skip object A and B
@@ -196,9 +197,9 @@ def build_dataset():
                    (A[0] <= other_objx <= B[0] and B[1] <= other_objy <= A[1]) or \
                    (B[0] <= other_objx <= A[0] and B[1] <= other_objy <= A[1]) or \
                    (B[0] <= other_objx <= A[0] and A[1] <= other_objy <= B[1]):
-                    between_count += 1
+                    answer = 0  # change answer to 'yes'
+                    break
 
-            answer = between_count + 4
         elif subtype == 1:
             """is-on-band->yes/no"""
             

--- a/sort_of_clevr_generator.py
+++ b/sort_of_clevr_generator.py
@@ -192,23 +192,24 @@ def build_dataset():
         if subtype == 0:
             """between->yes/no"""
 
-            sampling_bias = 0.35  # increasing will obtain more positive classes
+            sampling_bias = 0.35  # balance answer classes
 
             answer = 1  # default answer is 'no'
 
             if random.random() > sampling_bias:
                 answer = between_check(A, color1, B, color2, objects)
             else:
-                for color2 in rnd_colors[1:]:
-                    B = objects[color2][1]
+                for color in rnd_colors[1:]:
                     if answer == 0:  # stop the check if the answer is already a yes
                         break
+                    color2 = color
+                    B = objects[color2][1]
                     answer = between_check(A, color1, B, color2, objects)
 
         elif subtype == 1:
             """is-on-band->yes/no"""
             
-            grace_threshold = 12  # half of the size of objects
+            grace_threshold = 12
             epsilon = 1e-10  
             m = (B[1]-A[1])/((B[0]-A[0]) + epsilon ) # add epsilon to prevent dividing by zero
             c = A[1] - (m*A[0])


### PR DESCRIPTION
After modifying the answer generation to output yes/no answers, I have found that about 70% of the times the answer was ‘no’ and after implementation the discussed sampling method, I have found that % of ‘no’ dropped to approx. 20%. Therefore, I added a sampling bias variable to control the yes/no split. With the new modifications, we are able to obtain about a 50/50 split. 

Furthermore, I moved the ternary question embedding generation to the end of the for-loop. This is to make sure that the right object is encoded into the question embedding after resampling. 